### PR TITLE
デザイン・UI・環境設定の全面改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# メール送信サービス（Resend）
+# https://resend.com でAPIキーを取得してください
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# 送信元メールアドレス
+# Resend で認証済みのドメインのアドレスを使用してください
+MAIL_FROM=noreply@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*
@@ -38,3 +39,4 @@
 !/app/assets/builds/.keep
 
 /node_modules/
+.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,6 +442,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin-24
   arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu

--- a/README.md
+++ b/README.md
@@ -2,31 +2,87 @@
 
 ## サービス概要
 
-サブスク管理は、自分が利用しているサブスクを確認することができるサービスです。ユーザーは、自分が利用しているサブスクのプラン・金額・支払いタイミングを登録することができます。また、登録しているサブスクの支払いタイミングをサービスがメールで通知してくれます。
+サブスク管理は、自分が利用しているサブスクを一元管理できるサービスです。サービス名・金額・支払いサイクルを登録すると、毎月の合計支払い額を確認でき、支払日が近づいたらメールでお知らせします。
 
 ## URL
+
 https://www.subscmanage.com
 
 ## スクリーンショット
+
 <img width="545" height="672" alt="スクリーンショット 2026-04-19 21 52 29" src="https://github.com/user-attachments/assets/110988d6-4005-413e-a15d-1d437eb249f4" />
 
 <img width="502" height="519" alt="スクリーンショット 2026-04-19 21 52 54" src="https://github.com/user-attachments/assets/81b95451-900d-4d95-80d6-1ffdf4f6bc72" />
 
-## 動作環境
+## 技術スタック
 
-* Ruby 3.4.7
-* Ruby on Rails 8.1.1
+| カテゴリ | 技術 |
+|---|---|
+| バックエンド | Ruby 3.4.7 / Ruby on Rails 8.1.1 |
+| フロントエンド | Tailwind CSS v4 / Stimulus.js / Turbo |
+| データベース | PostgreSQL |
+| 認証 | Devise |
+| メール送信 | Resend |
+| デプロイ | Kamal |
 
 ## 環境構築
 
-### リポジトリの取得
-```
+### 1. リポジトリの取得
+
+```bash
 git clone https://github.com/thmz337/subscmanage.git
 cd subscmanage
+```
+
+### 2. 環境変数の設定
+
+`.env.example` をコピーして `.env` を作成し、各値を設定してください。
+
+```bash
+cp .env.example .env
+```
+
+| 変数名 | 説明 |
+|---|---|
+| `RESEND_API_KEY` | [Resend](https://resend.com) で発行したAPIキー |
+| `MAIL_FROM` | Resend で認証済みドメインの送信元メールアドレス |
+
+### 3. セットアップ
+
+```bash
 bin/setup
 ```
 
-### アプリの起動
+### 4. 初期データの投入
+
+```bash
+bin/rails db:seed
 ```
+
+開発環境では以下のユーザーが作成されます。
+
+| ロール | メールアドレス | パスワード |
+|---|---|---|
+| 管理者 | admin@example.com | password |
+| 一般ユーザー | user@example.com | password |
+
+### 5. アプリの起動
+
+```bash
 foreman start -f Procfile.dev
+```
+
+アプリは http://localhost:5000 で起動します。
+
+### メール確認（開発環境）
+
+開発環境では送信メールを letter_opener で確認できます。
+
+http://localhost:5000/letter_opener
+
+## テスト
+
+```bash
+bin/rails test
+bin/rails test:system
 ```

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,13 @@
 module ApplicationHelper
   def flash_css_class(key)
-    base = "mx-auto max-w-md p-4 rounded"
+    base = "toast w-72 rounded-xl shadow-lg px-4 py-3 border transition-all duration-300"
     case key.to_sym
     when :notice
-      "#{base} bg-green-100 text-green-800"
+      "#{base} bg-green-50 text-green-800 border-green-200"
     when :alert
-      "#{base} bg-red-100 text-red-800"
+      "#{base} bg-red-50 text-red-800 border-red-200"
     else
-      "#{base} bg-blue-100 text-blue-800"
+      "#{base} bg-blue-50 text-blue-800 border-blue-200"
     end
-    end
+  end
 end

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.timer = setTimeout(() => this.dismiss(), 4000)
+  }
+
+  disconnect() {
+    clearTimeout(this.timer)
+  }
+
+  dismiss() {
+    this.element.classList.add("opacity-0", "translate-x-4")
+    setTimeout(() => this.element.remove(), 300)
+  }
+}

--- a/app/views/account/passwords/edit.html.erb
+++ b/app/views/account/passwords/edit.html.erb
@@ -1,46 +1,59 @@
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("devise.passwords.edit.change_my_password") %>
-</h2>
+<% content_for :title, t("devise.passwords.edit.change_my_password") %>
 
-<%= form_with(model: current_user, url: account_password_path, method: :put) do |f| %>
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :current_password, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= f.password_field :current_password, autocomplete: "current-password",
-	class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full
-		py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= current_user.errors.full_messages_for(:current_password).first %>
+<div class="mx-auto max-w-md px-4 py-8">
+  <div class="flex items-center gap-3 mb-4">
+    <%= link_to edit_user_registration_path, class: "text-gray-400 hover:text-gray-600 transition" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+    <% end %>
+    <h1 class="text-2xl font-bold text-gray-900"><%= t("devise.passwords.edit.change_my_password") %></h1>
   </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <div class="flex">
-      <%= f.label :password, class: "pb-1 text-gray-700" %>
-      <% if @minimum_password_length %>
-      <%= t('devise.shared.minimum_password_length', count: @minimum_password_length, class: "text-gray-700") %>
-      <% end %>
-    </div>
-    <%= f.password_field :password, autocomplete: "new-password",
-	class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full
-		py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= current_user.errors.full_messages_for(:password).first %>
-  </div>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-6">
+    <%= form_with(model: current_user, url: account_password_path, method: :put) do |f| %>
+      <div class="space-y-4">
+        <div class="form-field">
+          <%= f.label :current_password, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.password_field :current_password, autocomplete: "current-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <p class="mt-1 text-xs text-gray-500">本人確認のために現在のパスワードを入力してください。</p>
+          <% if current_user.errors.include?(:current_password) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= current_user.errors.full_messages_for(:current_password).first %></p>
+          <% end %>
+        </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :password_confirmation, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password",
-	class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full
-		py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= current_user.errors.full_messages_for(:password_confirmation).first %>
-  </div>
+        <div class="form-field">
+          <div class="flex items-baseline gap-2 mb-1">
+            <%= f.label :password, class: "form-field__label text-sm font-semibold text-gray-700" %>
+            <% if @minimum_password_length %>
+            <span class="text-xs text-gray-400">(<%= @minimum_password_length %>文字以上)</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if current_user.errors.include?(:password) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= current_user.errors.full_messages_for(:password).first %></p>
+          <% end %>
+        </div>
 
-  <div class="actions mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.submit t("devise.passwords.edit.change_my_password"),
-	class: "bg-white border border-gray-300
-		px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+        <div class="form-field">
+          <%= f.label :password_confirmation, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if current_user.errors.include?(:password_confirmation) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= current_user.errors.full_messages_for(:password_confirmation).first %></p>
+          <% end %>
+        </div>
+
+        <div class="form-actions pt-1">
+          <%= f.submit t("devise.passwords.edit.change_my_password"),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/admin/service_presets/_form.html.erb
+++ b/app/views/admin/service_presets/_form.html.erb
@@ -1,52 +1,47 @@
 <%= form_with(model: admin_service_preset) do |form| %>
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :name, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= form.text_field :name,
-	class: "border-1 border-indigo-300 shadow-sm appearance-none
-		rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline pr-24" %>
-  </div>
-  <% if admin_service_preset.errors.include?(:name) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= admin_service_preset.errors.full_messages_for(:name).first %>
-  </div>
-  <% end %>
-
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :payment_interval, style: "display: block", class: "pb-1 text-gray-700" %>
-    <div class="relative">
-      <%= form.number_field :payment_interval, min: 1,
-	  class: "border-1 border-indigo-300 shadow-sm appearance-none
-		  rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline pr-24"%>
-      <div class="absolute inset-y-0 right-0 flex items-center mr-2 ">
-	<%= form.select :payment_unit, [["ヶ月", "month"], ["年", "year"]] %>
-      </div>
+  <div class="p-6 space-y-5">
+    <div class="form-field">
+      <%= form.label :name, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+      <%= form.text_field :name,
+        class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+        focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+      <% if admin_service_preset.errors.include?(:name) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= admin_service_preset.errors.full_messages_for(:name).first %></p>
+      <% end %>
     </div>
-  </div>
-  <% if admin_service_preset.errors.include?(:payment_interval) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= admin_service_preset.errors.full_messages_for(:payment_interval).first %>
-  </div>
-  <% end %>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :price, style: "display: block", class: "pb-1 text-gray-700" %>
-    <div class="relative">
-      <%= form.text_field :price,
-	  class: "border-1 border-indigo-300 shadow-sm appearance-none
-		  rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline pr-24" %>
-       <div class="absolute inset-y-0 right-0 flex items-center mr-2 ">
-	<%= form.select :monetary_unit, [["円", "JPY"], ["$", "USD"]] %>
+    <div class="form-field">
+      <%= form.label :payment_interval, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+      <div class="form-field__row flex gap-2">
+        <%= form.number_field :payment_interval, min: 1,
+          class: "form-field__input block w-24 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        <%= form.select :payment_unit, [["ヶ月", "month"], ["年", "year"]], {},
+          class: "form-field__select w-24 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 bg-white
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none" %>
       </div>
+      <% if admin_service_preset.errors.include?(:payment_interval) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= admin_service_preset.errors.full_messages_for(:payment_interval).first %></p>
+      <% end %>
     </div>
-  </div>
-  <% if admin_service_preset.errors.include?(:price) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">    
-    <%= admin_service_preset.errors.full_messages_for(:price).first %>
-  </div>
-  <% end %>
-  
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.submit class: "bg-white border border-gray-300
-			    px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+
+    <div class="form-field">
+      <%= form.label :price, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+      <div class="form-field__row flex gap-2">
+        <%= form.text_field :price,
+          class: "form-field__input block w-32 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        <%= form.select :monetary_unit, [["円", "JPY"], ["$", "USD"]], {},
+          class: "form-field__select w-24 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 bg-white
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none" %>
+      </div>
+      <% if admin_service_preset.errors.include?(:price) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= admin_service_preset.errors.full_messages_for(:price).first %></p>
+      <% end %>
+    </div>
+
+    <div class="form-actions pt-1">
+      <%= form.submit class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/admin/service_presets/edit.html.erb
+++ b/app/views/admin/service_presets/edit.html.erb
@@ -1,14 +1,16 @@
 <% content_for :title, t("helpers.heading.edit", model: t("activerecord.models.admin.service_preset")) %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.heading.edit", model: t("activerecord.models.admin.service_preset")) %>
-</h2>
+<div class="mx-auto max-w-md px-4 py-8">
+  <h1 class="text-2xl font-bold text-gray-900 mb-6"><%= t("helpers.heading.edit", model: t("activerecord.models.admin.service_preset")) %></h1>
 
-<%= render "form", admin_service_preset: @admin_service_preset %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 mb-4">
+    <%= render "form", admin_service_preset: @admin_service_preset %>
+  </div>
 
-
-<div class="field mx-auto max-w-md pt-6 pl-6 pr-6 mt-8">
-  <%= button_to t("helpers.submit.delete"), admin_service_preset_path,
-      data: { confirm: "Are you sure?", turbo_confirm: "本当に削除しますか？" }, method: :delete,
-      class: "bg-red-600 border border-red-300 text-white px-4 py-2 rounded hover:bg-red-800 hover:cursor-pointer shadow-sm transition" %>
+  <div class="bg-white rounded-2xl shadow-sm border border-red-100 p-5">
+    <p class="text-sm text-gray-500 mb-3">このプリセットを削除すると元に戻せません。</p>
+    <%= button_to t("helpers.submit.delete"), admin_service_preset_path(@admin_service_preset),
+        data: { turbo_confirm: "本当に削除しますか？" }, method: :delete,
+        class: "bg-white border border-red-300 text-red-600 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-red-50 cursor-pointer transition" %>
+  </div>
 </div>

--- a/app/views/admin/service_presets/index.html.erb
+++ b/app/views/admin/service_presets/index.html.erb
@@ -1,14 +1,19 @@
-<% content_for :title, "Service presets" %>
+<% content_for :title, t("helpers.heading.admin") %>
 
-<h1>Service presets</h1>
+<div class="mx-auto max-w-2xl px-4 py-8">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">プリセット一覧</h1>
+    <%= link_to t("activerecord.attributes.admin/service_preset.new"), new_admin_service_preset_path,
+      class: "bg-indigo-600 text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-indigo-700 transition" %>
+  </div>
 
-<div id="admin_service_presets">
-  <% @admin_service_presets.each do |admin_service_preset| %>
-    <%= render admin_service_preset %>
-    <p>
-      <%= link_to "Show this service preset", admin_service_preset %>
-    </p>
-  <% end %>
+  <div class="space-y-2">
+    <% @admin_service_presets.each do |admin_service_preset| %>
+    <div class="bg-white border border-gray-200 rounded-xl overflow-hidden hover:border-indigo-300 transition">
+      <%= link_to edit_admin_service_preset_path(admin_service_preset), class: "block" do %>
+        <%= render admin_service_preset %>
+      <% end %>
+    </div>
+    <% end %>
+  </div>
 </div>
-
-<%= link_to "New service preset", new_admin_service_preset_path %>

--- a/app/views/admin/service_presets/new.html.erb
+++ b/app/views/admin/service_presets/new.html.erb
@@ -1,15 +1,9 @@
 <% content_for :title, t("helpers.heading.new", model: t("activerecord.models.admin.service_preset")) %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.heading.new", model: t("activerecord.models.admin.service_preset")) %>
-</h2>
+<div class="mx-auto max-w-md px-4 py-8">
+  <h1 class="text-2xl font-bold text-gray-900 mb-6"><%= t("helpers.heading.new", model: t("activerecord.models.admin.service_preset")) %></h1>
 
-<%= render "form", admin_service_preset: @admin_service_preset %>
-
-<br>
-
-<!--
-<div>
-<%= link_to t("helpers.back", model: t("activerecord.models.admin.service_preset")), admin_root_path %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200">
+    <%= render "form", admin_service_preset: @admin_service_preset %>
+  </div>
 </div>
--->

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,31 @@
-<h2><%= t('devise.confirmations.new.resend_confirmation_instructions') %></h2>
+<% content_for :title, t('devise.confirmations.new.resend_confirmation_instructions') %>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-2"><%= t('devise.confirmations.new.resend_confirmation_instructions') %></h1>
+    <p class="text-sm text-gray-500 mb-6">メール確認のリンクを再送します。登録済みのメールアドレスを入力してください。</p>
 
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <%= f.label :email, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        </div>
+
+        <div class="form-actions pt-1">
+          <%= f.submit t('devise.confirmations.new.resend_confirmation_instructions'),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
-  <div class="actions">
-    <%= f.submit t('devise.confirmations.new.resend_confirmation_instructions') %>
+  <div class="auth-links mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,38 +1,44 @@
 <% content_for :title, t("helpers.heading.password") %>
 <% content_for :description, "サブスク管理のパスワード変更画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t('devise.passwords.edit.change_your_password') %>
-</h2>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-6"><%= t('devise.passwords.edit.change_your_password') %></h1>
 
-<%= form_with(model: @user, url: user_password_path, method: :put) do |f| %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_with(model: @user, url: user_password_path, method: :put) do |f| %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <div class="flex">
-      <%= f.label :password, t('devise.passwords.edit.new_password'), class: "pb-1 text-gray-700" %>
-      <% if @minimum_password_length %>
-      <%= t('devise.shared.minimum_password_length', count: @minimum_password_length, class: "text-gray-700") %>
-      <% end %>
-    </div>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= @user.errors.full_messages_for(:password).first %>
-  </div>
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <div class="flex items-baseline gap-2 mb-1">
+            <%= f.label :password, t('devise.passwords.edit.new_password'), class: "form-field__label text-sm font-semibold text-gray-700" %>
+            <% if @minimum_password_length %>
+            <span class="text-xs text-gray-400">(<%= @minimum_password_length %>文字以上)</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if @user.errors.include?(:password) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= @user.errors.full_messages_for(:password).first %></p>
+          <% end %>
+        </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :password_confirmation, t('devise.passwords.edit.confirm_new_password'), style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= @user.errors.full_messages_for(:password_confirmation).first %>
-  </div>
+        <div class="form-field">
+          <%= f.label :password_confirmation, t('devise.passwords.edit.confirm_new_password'), class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if @user.errors.include?(:password_confirmation) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= @user.errors.full_messages_for(:password_confirmation).first %></p>
+          <% end %>
+        </div>
 
-  <div class="actions mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.submit t('devise.passwords.edit.change_my_password'),
-      class: "bg-white border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+        <div class="form-actions pt-1">
+          <%= f.submit t('devise.passwords.edit.change_my_password'),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,30 @@
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t('devise.shared.links.forgot_your_password') %>
-</h2>
+<% content_for :title, t('devise.shared.links.forgot_your_password') %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-2"><%= t('devise.shared.links.forgot_your_password') %></h1>
+    <p class="text-sm text-gray-500 mb-6">登録済みのメールアドレスを入力してください。パスワード再設定のリンクをお送りします。</p>
 
-  <div class="field  mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :email, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <%= f.label :email, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        </div>
+
+        <div class="form-actions pt-1">
+          <%= f.submit t("devise.passwords.new.send_me_reset_password_instructions"),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
-  <div class="actions mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.submit t("devise.passwords.new.send_me_reset_password_instructions"),
-      class: "bg-white border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+  <div class="auth-links mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,35 +1,57 @@
 <% content_for :title, t("helpers.heading.edit", model: t("activerecord.models.user")) %>
 <% content_for :description, "サブスク管理のユーザー編集画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t('devise.registrations.edit.title', resource: t('activerecord.models.user')) %>
-</h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :email, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+<div class="mx-auto max-w-md px-4 py-8">
+  <div class="flex items-center gap-3 mb-4">
+    <%= link_to subscription_services_path, class: "text-gray-400 hover:text-gray-600 transition" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+    <% end %>
+    <h1 class="text-2xl font-bold text-gray-900"><%= t('devise.registrations.edit.title', resource: t('activerecord.models.user')) %></h1>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 mb-4">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.submit t('devise.registrations.edit.update'),
-      class: "bg-white border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition"%>
+      <div class="space-y-4">
+        <div>
+          <%= f.label :email, class: "block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <p class="mt-1 text-xs text-gray-500">変更すると確認メールが送信されます。メール内のリンクをクリックすると反映されます。</p>
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <p class="mt-1 text-xs text-amber-600">確認待ちのメールアドレス: <%= resource.unconfirmed_email %></p>
+          <% end %>
+        </div>
+
+        <div class="pt-1">
+          <%= f.submit t('devise.registrations.edit.update'),
+            class: "w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
 
-<div class="mx-auto max-w-md pt-12 pl-6 ">
-  <%= link_to t('devise.shared.links.change_password_from_here'), edit_account_password_path,
-      class: "font-medium text-blue-600 hover:underline" %>
-</div>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5 space-y-3">
+    <%= link_to edit_account_password_path,
+        class: "flex items-center gap-2 text-sm text-indigo-700 hover:text-indigo-900 font-medium" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+      </svg>
+      <%= t('devise.shared.links.change_password_from_here') %>
+    <% end %>
 
-<div class="mx-auto max-w-md pt-12 pl-6 ">
-  <%= link_to t('devise.shared.links.cancel_account_from_here'), account_cancel_path,
-      class: "font-medium text-blue-600 hover:underline" %>
+    <div class="border-t border-gray-200 pt-3">
+      <%= link_to account_cancel_path,
+          class: "flex items-center gap-2 text-sm text-red-500 hover:text-red-700 font-medium" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        <%= t('devise.shared.links.cancel_account_from_here') %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,62 +1,66 @@
 <% content_for :title, t("helpers.heading.new", model: t("activerecord.models.user")) %>
 <% content_for :description, "サブスク管理のユーザー登録画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t('devise.registrations.new.sign_up') %>
-</h2>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-6"><%= t('devise.registrations.new.sign_up') %></h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :email, display: "block", class: "pb-1 text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <% if resource.errors.include?(:email) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= resource.errors.full_messages_for(:email).first %>
-  </div>
-  <% end %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <%= f.label :email, class: "form-field__label block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if resource.errors.include?(:email) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= resource.errors.full_messages_for(:email).first %></p>
+          <% end %>
+        </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :email_confirmation, display: "block", class: "pb-1 text-gray-700" %>
-    <%= f.email_field :email_confirmation, autofocus: true, autocomplete: "email",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <% if resource.errors.include?(:email_confirmation) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= resource.errors.full_messages_for(:email_confirmation).first %>
-  </div>
-  <% end %>
+        <div class="form-field">
+          <%= f.label :email_confirmation, class: "form-field__label block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.email_field :email_confirmation, autocomplete: "email",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if resource.errors.include?(:email_confirmation) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= resource.errors.full_messages_for(:email_confirmation).first %></p>
+          <% end %>
+        </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <div class="flex">
-      <%= f.label :password, class: "pb-1 text-gray-700" %>
-      <% if @minimum_password_length %>
-      <%= t('devise.shared.minimum_password_length', count: @minimum_password_length, class: "text-gray-700") %>
-      <% end %>
-    </div>
-    <%= f.password_field :password, autocomplete: "new-password",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <% if resource.errors.include?(:password) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= resource.errors.full_messages_for(:password).first %>
-  </div>
-  <% end %>
+        <div class="form-field">
+          <div class="form-field__label-row flex items-baseline gap-2 mb-1">
+            <%= f.label :password, class: "form-field__label text-sm font-medium text-gray-700" %>
+            <% if @minimum_password_length %>
+            <span class="form-field__hint text-xs text-gray-400">(<%= @minimum_password_length %>文字以上)</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if resource.errors.include?(:password) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= resource.errors.full_messages_for(:password).first %></p>
+          <% end %>
+        </div>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.label :password_confirmation, display: "block", class: "pb-1 text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <% if resource.errors.include?(:password_confirmation) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= resource.errors.full_messages_for(:password_confirmation).first %>
-  </div>
-  <% end %>
+        <div class="form-field">
+          <%= f.label :password_confirmation, class: "form-field__label block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+          <% if resource.errors.include?(:password_confirmation) %>
+          <p class="form-field__error mt-1 text-sm text-red-600"><%= resource.errors.full_messages_for(:password_confirmation).first %></p>
+          <% end %>
+        </div>
 
-  <div class="actions mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= f.submit t('devise.registrations.new.sign_up'),
-      class: "bg-white border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+        <div class="form-actions pt-1">
+          <%= f.submit t('devise.registrations.new.sign_up'),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+
+  <div class="auth-links mt-4 text-center">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,34 +1,42 @@
 <% content_for :title, t("helpers.heading.user.login") %>
 <% content_for :description, "サブスク管理のログイン画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl font-bold">
-  <%= t('devise.sessions.new.sign_in') %>
-</h2>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-6"><%= t('devise.sessions.new.sign_in') %></h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field mx-auto max-w-md p-6">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <%= f.label :email, class: "form-field__label block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        </div>
+
+        <div class="form-field">
+          <%= f.label :password, class: "form-field__label block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.password_field :password, autocomplete: "current-password",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+        <div class="form-field form-field--checkbox flex items-center gap-2">
+          <%= f.check_box :remember_me, class: "form-field__checkbox size-4 rounded border-gray-300 text-indigo-600" %>
+          <%= f.label :remember_me, class: "form-field__checkbox-label text-sm text-gray-600" %>
+        </div>
+        <% end %>
+
+        <div class="form-actions pt-1">
+          <%= f.button t('devise.sessions.new.sign_in'),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
-  <div class="field mx-auto max-w-md p-6">
-    <%= f.label :password, class: "text-sm font-medium text-gray-700" %><br>
-    <%= f.password_field :password, autocomplete: "current-password",
-      class: "border-1 border-indigo-300 shadow-sm appearance-none rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+  <div class="auth-links mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field mx-auto max-w-md p-6">
-      <%= f.check_box :remember_me, class: "size-5 rounded border-gray-300 shadow-sm" %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="mx-auto max-w-md p-6">
-    <%= f.button t('devise.sessions.new.sign_in'),class: "bg-white border border-gray-300
-      px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,30 @@
-<h2><%= t('devise.unlocks.new.resend_unlock_instructions') %></h2>
+<% content_for :title, t('devise.unlocks.new.resend_unlock_instructions') %>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="auth-page mx-auto max-w-md px-4 py-10">
+  <div class="auth-card bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <h1 class="auth-card__title text-2xl font-bold text-gray-900 mb-2"><%= t('devise.unlocks.new.resend_unlock_instructions') %></h1>
+    <p class="text-sm text-gray-500 mb-6">アカウントのロック解除リンクを再送します。登録済みのメールアドレスを入力してください。</p>
 
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="auth-form space-y-4">
+        <div class="form-field">
+          <%= f.label :email, class: "form-field__label block text-sm font-semibold text-gray-700 mb-1" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+            focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        </div>
+
+        <div class="form-actions pt-1">
+          <%= f.submit t('devise.unlocks.new.resend_unlock_instructions'),
+            class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
-  <div class="actions">
-    <%= f.submit t('devise.unlocks.new.resend_unlock_instructions') %>
+  <div class="auth-links mt-4 text-center">
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,21 +1,107 @@
 <% content_for :title, t("helpers.heading.service_name") %>
 <% content_for :description, "サブスク管理のトップページです。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.service_name") %>
-</h2>
+<%# ── Hero ── %>
+<section class="hero bg-gradient-to-b from-indigo-50 to-white pt-14 pb-10 px-4 border-b border-indigo-100">
+  <div class="hero__inner mx-auto max-w-2xl text-center">
+    <h1 class="hero__title text-4xl sm:text-5xl font-bold text-indigo-900 mb-4 leading-tight">
+      毎月のサブスク代、<br>把握できていますか？
+    </h1>
+    <p class="hero__description text-base text-gray-500 mb-8 leading-relaxed">
+      Netflix・Spotify・Amazon… 気づかないうちに<br>
+      月々の出費が積み上がっていませんか？<br>
+      <span class="text-gray-700 font-medium">サブスク管理</span>なら、登録するだけで<br>
+      合計金額と支払い日を一元管理。<br>支払い日にはメールでお知らせします。
+    </p>
+    <div class="hero__actions">
+      <%= link_to "無料で始める", new_user_registration_path,
+          class: "hero__cta-primary inline-block w-64 bg-indigo-600 text-white font-bold py-4 rounded-xl hover:bg-indigo-700 transition text-base text-center" %>
+      <div class="mt-3">
+        <%= link_to "ログイン", new_user_session_path,
+            class: "hero__cta-secondary text-sm text-gray-400 hover:text-gray-600 hover:underline transition" %>
+      </div>
+    </div>
+  </div>
+</section>
 
-<div class="mx-auto max-w-md p-6">
-  <p>登録しているサブスクリプションを管理できるサービスです</p>
-</div>
+<%# ── App preview mock ── %>
+<section class="app-preview bg-gray-50 py-12 px-4 border-b border-gray-200">
+  <div class="app-preview__inner mx-auto max-w-2xl">
+    <p class="app-preview__label text-center text-xs font-semibold text-gray-400 uppercase tracking-widest mb-6">アプリのイメージ</p>
+    <div class="app-preview__card bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden max-w-sm mx-auto">
+      <div class="app-preview__summary bg-indigo-600 px-5 py-4 text-white">
+        <p class="app-preview__summary-label text-xs text-indigo-200 font-medium mb-0.5">今月の支払額</p>
+        <p class="app-preview__summary-amount text-3xl font-bold tracking-tight">3,080<span class="text-lg font-medium ml-1">円</span></p>
+        <p class="app-preview__summary-count text-xs text-indigo-300 mt-1">3件のサービス</p>
+      </div>
+      <div class="app-preview__list divide-y divide-gray-100">
+        <div class="app-preview__item flex items-center gap-3 px-5 py-3.5">
+          <div class="app-preview__item-info flex-1">
+            <p class="app-preview__item-name font-semibold text-sm text-gray-900">Netflix</p>
+            <p class="app-preview__item-meta text-xs text-gray-400 mt-0.5">次回 <%= (Date.today + 18).strftime("%Y/%m/%d") %> &nbsp;·&nbsp; 1ヶ月ごと</p>
+          </div>
+          <p class="app-preview__item-price font-bold text-sm text-gray-900 shrink-0">1,590<span class="text-xs font-normal text-gray-400">円</span></p>
+          <svg xmlns="http://www.w3.org/2000/svg" class="size-3.5 text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+        <div class="app-preview__item flex items-center gap-3 px-5 py-3.5">
+          <div class="app-preview__item-info flex-1">
+            <p class="app-preview__item-name font-semibold text-sm text-gray-900">Spotify</p>
+            <p class="app-preview__item-meta text-xs text-gray-400 mt-0.5">次回 <%= (Date.today + 23).strftime("%Y/%m/%d") %> &nbsp;·&nbsp; 1ヶ月ごと</p>
+          </div>
+          <p class="app-preview__item-price font-bold text-sm text-gray-900 shrink-0">980<span class="text-xs font-normal text-gray-400">円</span></p>
+          <svg xmlns="http://www.w3.org/2000/svg" class="size-3.5 text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+        <div class="app-preview__item flex items-center gap-3 px-5 py-3.5">
+          <div class="app-preview__item-info flex-1">
+            <p class="app-preview__item-name font-semibold text-sm text-gray-900">Amazon Prime</p>
+            <p class="app-preview__item-meta text-xs text-gray-400 mt-0.5">次回 <%= (Date.today + 35).strftime("%Y/%m/%d") %> &nbsp;·&nbsp; 1ヶ月ごと</p>
+          </div>
+          <p class="app-preview__item-price font-bold text-sm text-gray-900 shrink-0">510<span class="text-xs font-normal text-gray-400">円</span></p>
+          <svg xmlns="http://www.w3.org/2000/svg" class="size-3.5 text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
-<div class="mx-auto max-w-md p-6">
-  <button class="bg-white border border-gray-300 px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition">
-    <%= link_to t("helpers.login"), new_user_session_path %>
-  </button>
-</div>
+<%# ── How it works ── %>
+<section class="how-it-works mx-auto max-w-2xl px-4 py-12">
+  <p class="how-it-works__label text-center text-xs font-semibold text-gray-400 uppercase tracking-widest mb-8">使い方 3ステップ</p>
+  <div class="how-it-works__steps flex flex-col gap-6">
+    <div class="step flex gap-5 items-start">
+      <div class="step__number w-9 h-9 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold text-sm shrink-0 shadow-sm">1</div>
+      <div class="step__content bg-white rounded-xl p-5 shadow-sm border border-gray-200 flex-1">
+        <h3 class="step__title font-bold text-gray-900 mb-1">サブスクを登録する</h3>
+        <p class="step__description text-sm text-gray-500 leading-relaxed">サービス名・金額・次回支払日を入力するだけ。よく使われるサービスはサービス名を入力すると自動で金額が補完されます。</p>
+      </div>
+    </div>
+    <div class="step flex gap-5 items-start">
+      <div class="step__number w-9 h-9 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold text-sm shrink-0 shadow-sm">2</div>
+      <div class="step__content bg-white rounded-xl p-5 shadow-sm border border-gray-200 flex-1">
+        <h3 class="step__title font-bold text-gray-900 mb-1">一覧で確認する</h3>
+        <p class="step__description text-sm text-gray-500 leading-relaxed">登録したサブスクが一覧に並び、今月の合計金額が自動で計算されます。「実はこんなに払っていた」が一目でわかります。</p>
+      </div>
+    </div>
+    <div class="step flex gap-5 items-start">
+      <div class="step__number w-9 h-9 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold text-sm shrink-0 shadow-sm">3</div>
+      <div class="step__content bg-white rounded-xl p-5 shadow-sm border border-gray-200 flex-1">
+        <h3 class="step__title font-bold text-gray-900 mb-1">支払い日にメールが届く</h3>
+        <p class="step__description text-sm text-gray-500 leading-relaxed">支払い日が近づくと自動でメールが届きます。うっかり忘れることなく、支払いを把握できます。</p>
+      </div>
+    </div>
+  </div>
+</section>
 
-<div class="mx-auto max-w-md pl-6">
-  <%= link_to t("helpers.register"), new_user_registration_path,
-      class: "font-medium text-blue-600 hover:underline" %>
-</div>
+<%# ── Bottom CTA ── %>
+<section class="cta-section bg-indigo-600 py-12 px-4 text-center">
+  <h2 class="cta-section__title text-2xl font-bold text-white mb-2">まずは無料で試してみる</h2>
+  <p class="cta-section__description text-indigo-200 text-sm mb-6">登録はメールアドレスだけ。1分で完了します。</p>
+  <%= link_to "無料で始める", new_user_registration_path,
+      class: "cta-section__button inline-block bg-white text-indigo-700 font-bold px-8 py-4 rounded-xl hover:bg-indigo-50 transition text-base" %>
+</section>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,11 +1,11 @@
-<div class="mx-auto max-w-md px-4 py-16 sm:px-6 lg:px-8">
-  <ul class="mt-12 flex flex-wrap justify-center gap-6 md:gap-8 lg:gap-12">
-    <li>
-      <%= link_to t("helpers.term"), page_path("terms"), class: "font-medium text-blue-600 hover:underline" %>
+<div class="site-footer__inner mx-auto max-w-2xl px-4 py-6">
+  <ul class="site-footer__links flex flex-wrap justify-center gap-6 text-sm">
+    <li class="site-footer__link-item">
+      <%= link_to t("helpers.term"), page_path("terms"), class: "site-footer__link text-gray-500 hover:text-gray-700 hover:underline" %>
     </li>
-
-    <li>
-      <%= link_to t("helpers.policy"), page_path("privacy_policy"), class: "font-medium text-blue-600 hover:underline" %>
+    <li class="site-footer__link-item">
+      <%= link_to t("helpers.policy"), page_path("privacy_policy"), class: "site-footer__link text-gray-500 hover:text-gray-700 hover:underline" %>
     </li>
   </ul>
+  <p class="mt-4 text-center text-xs text-gray-400">© 2026 サブスク管理 All Rights Reserved.</p>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,43 +1,53 @@
-<div class="mx-auto max-w-md px-4 sm:px-6 lg:px-8">
-  <div class="flex h-16 items-center justify-between">
-    <div class="flex-1 md:flex md:items-center md:gap-12 text-3xl font-bold">
-      <%= link_to t("helpers.service_name"), root_path, class: "block" %>
+<nav class="site-nav mx-auto max-w-2xl px-4">
+  <div class="site-nav__inner flex h-16 items-center justify-between">
+    <div class="site-nav__logo flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+      </svg>
+      <%= link_to t("helpers.service_name"), root_path, class: "site-nav__brand text-lg font-bold text-indigo-700 tracking-tight" %>
     </div>
 
     <% if user_signed_in? %>
-    <div class="md:flex md:items-center md:gap-12">
-      <div
-        data-controller="dropdown"
-        data-action="click@window->dropdown#hide touchstart@window->dropdown#hide
-        keydown.up->dropdown#previousItem keydown.down->dropdown#nextItem keydown.esc->dropdown#hide"
-        class="inline-block relative">
-        <button data-action="dropdown#toggle:stop"
-          class="dropdown-menu-button block rounded-sm bg-gray-100 p-2.5 text-gray-600 transition hover:text-gray-600/75 cursor-pointer">
-          <svg xmlns="http://www.w3.org/2000/svg" class="size-5" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"></path>
-          </svg>
-        </button>
-        <div data-dropdown-target="menu"
-          class="dropdown-menu hidden absolute right-0 z-20 mt-2 w-40 origin-top-right rounded-md border border-gray-200
-          bg-white shadow-lg ring-1 ring-black/5 transition transform opacity-0 scale-95
-          data-[state=open]:block data-[state=open]:opacity-100 data-[state=open]:scale-100">
-          <div class="py-1 text-sm text-gray-700">
-            <%= link_to t("activerecord.attributes.user.edit"), edit_user_registration_path,
-              data: { dropdown_target: "menuItem" },
-              class: "block px-4 py-2 hover:bg-gray-50 hover:text-gray-900 focus:bg-gray-50 focus:text-gray-900" %>
-            <% if current_user.admin? %>
-            <%= link_to t("helpers.admin"), admin_root_path, data: { dropdown_target: "menuItem" },
-              class: "block px-4 py-2 hover:bg-gray-50 hover:text-gray-900 focus:bg-gray-50 focus:text-gray-900" %>
-            <% end %>
-            <div class="my-1 border-t border-gray-300"></div>
-            <%= link_to t("helpers.logout"), destroy_user_session_path,
-              data: { turbo_method: :delete, dropdown_target: "menuItem" },
-              class: "block px-4 py-2 hover:bg-gray-50 hover:text-gray-900 focus:bg-gray-50 focus:text-gray-900" %>
-          </div>
+    <div
+      data-controller="dropdown"
+      data-action="click@window->dropdown#hide touchstart@window->dropdown#hide
+      keydown.up->dropdown#previousItem keydown.down->dropdown#nextItem keydown.esc->dropdown#hide"
+      class="site-nav__dropdown relative inline-block">
+      <button data-action="dropdown#toggle:stop"
+        class="dropdown-menu-button site-nav__dropdown-trigger inline-flex items-center gap-2 rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-700 hover:bg-gray-200 transition cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div data-dropdown-target="menu"
+        class="dropdown-menu site-nav__dropdown-menu hidden absolute right-0 z-20 mt-2 w-44 origin-top-right rounded-xl border border-gray-200
+        bg-white shadow-lg ring-1 ring-black/5 transition transform opacity-0 scale-95
+        data-[state=open]:block data-[state=open]:opacity-100 data-[state=open]:scale-100">
+        <div class="site-nav__dropdown-items py-1 text-sm text-gray-700">
+          <%= link_to t("activerecord.attributes.user.edit"), edit_user_registration_path,
+            data: { dropdown_target: "menuItem" },
+            class: "site-nav__dropdown-item block px-4 py-2.5 hover:bg-gray-50 hover:text-gray-900 rounded-t-xl" %>
+          <% if current_user.admin? %>
+          <%= link_to t("helpers.admin"), admin_root_path, data: { dropdown_target: "menuItem" },
+            class: "site-nav__dropdown-item block px-4 py-2.5 hover:bg-gray-50 hover:text-gray-900" %>
+          <% end %>
+          <div class="site-nav__dropdown-divider my-1 border-t border-gray-100"></div>
+          <%= link_to t("helpers.logout"), destroy_user_session_path,
+            data: { turbo_method: :delete, dropdown_target: "menuItem" },
+            class: "site-nav__dropdown-item site-nav__dropdown-item--danger block px-4 py-2.5 text-red-600 hover:bg-red-50 hover:text-red-700 rounded-b-xl" %>
         </div>
       </div>
     </div>
+    <% else %>
+    <div class="site-nav__actions flex items-center gap-3">
+      <%= link_to "ログイン", new_user_session_path,
+          class: "site-nav__login text-sm font-medium text-indigo-700 hover:text-indigo-900 transition" %>
+      <%= link_to "新規登録", new_user_registration_path,
+          class: "site-nav__register text-sm font-semibold bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition" %>
+    </div>
     <% end %>
   </div>
-</div>
+</nav>

--- a/app/views/layouts/admin_application.html.erb
+++ b/app/views/layouts/admin_application.html.erb
@@ -1,38 +1,22 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
-    <title><%= content_for(:title) || "Subscmanage" %></title>
+    <title><%= content_for(:title) || "Subscmanage 管理" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Subscmanage">
-    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= yield :head %>
-
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
-
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <header class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
-    <%= render "layouts/admin_header" %>
-  </header>
-
-  <body class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
+  <body class="bg-gray-50 min-h-screen">
     <%= render "shared/flash" %>
-    <%= yield %>
+    <main class="mx-auto max-w-7xl px-4 py-8">
+      <%= yield %>
+    </main>
   </body>
-
-  <footer class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
-    <%= render "layouts/footer" %>
-  </footer>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,6 @@
 
     <%= yield :head %>
 
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
-
     <%= favicon_link_tag("favicon.ico") %>
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
@@ -25,16 +22,16 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <header class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
-    <%= render "layouts/header" %>
-  </header>
-
-  <body class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
-    <%= render "shared/flash" %>
-    <%= yield %>
+  <body class="site-body bg-gray-50 min-h-screen flex flex-col">
+    <header class="site-header bg-white shadow-sm border-b border-gray-200 sticky top-0 z-30">
+      <%= render "layouts/header" %>
+    </header>
+    <main class="site-main flex-1">
+      <%= render "shared/flash" %>
+      <%= yield %>
+    </main>
+    <footer class="site-footer bg-white border-t border-gray-200 mt-auto">
+      <%= render "layouts/footer" %>
+    </footer>
   </body>
-
-  <footer class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
-    <%= render "layouts/footer" %>
-  </footer>
 </html>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,31 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-      /* Email styles need to be inline */
+      body { margin: 0; padding: 0; background-color: #f9fafb; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+      .wrapper { max-width: 560px; margin: 0 auto; padding: 32px 16px; }
+      .card { background: #ffffff; border-radius: 16px; border: 1px solid #e5e7eb; overflow: hidden; }
+      .header { background-color: #4f46e5; padding: 24px 32px; }
+      .header-title { color: #ffffff; font-size: 18px; font-weight: 700; margin: 0; }
+      .body { padding: 32px; }
+      .footer { padding: 24px 32px 0; text-align: center; color: #9ca3af; font-size: 12px; }
     </style>
   </head>
-
   <body>
-    <%= yield %>
+    <div class="wrapper">
+      <div class="card">
+        <div class="header">
+          <p class="header-title">サブスク管理</p>
+        </div>
+        <div class="body">
+          <%= yield %>
+        </div>
+      </div>
+      <div class="footer">
+        <p style="margin: 16px 0 0;">© 2026 サブスク管理 All Rights Reserved.</p>
+      </div>
+    </div>
   </body>
 </html>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,46 +1,38 @@
 <% content_for :title, t("helpers.heading.privacy_policy") %>
 
-<div class="max-w-4xl mx-auto px-6 py-12">
-  <div class="mb-12 text-center">
-    <h1 class="text-4xl font-blid text-gray-900 mb-4"><%= t("helpers.policy") %></h1>
-  </div>
+<div class="max-w-2xl mx-auto px-4 py-12">
+  <h1 class="text-3xl font-bold text-gray-900 mb-8"><%= t("helpers.policy") %></h1>
 
-  <div class="bg-white shadow-md rounded-2xl p-8 mb-10">
-    <p>
-      サブスク管理（以下，「運営者」といいます。）は，本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，
-      ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
-    </p>
-  </div>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 divide-y divide-gray-100">
+    <div class="p-8">
+      <p class="text-gray-600 leading-relaxed">
+        サブスク管理（以下，「運営者」といいます。）は，本ウェブサイト上で提供するサービス（以下，「本サービス」といいます。）における，
+        ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
+      </p>
+    </div>
 
-  <div class="space-y-10">
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第1条（個人情報）
-      </h2>
-      <p class="mb-2">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第1条（個人情報）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">
         「個人情報」とは，個人情報保護法にいう「個人情報」を指すものとし，生存する個人に関する情報であって，当該情報に含まれる氏名，生年月日，住所，電話番号，連絡先
         その他の記述等により特定の個人を識別できる情報及び容貌，指紋，声紋にかかるデータ，及び健康保険証の保険者番号などの
         当該情報単体から特定の個人を識別できる情報（個人識別情報）を指します。
       </p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第2条（個人情報の収集方法）
-      </h2>
-      <p class="mb-2">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第2条（個人情報の収集方法）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">
         運営者は，ユーザーが利用登録をする際に氏名，生年月日，住所，電話番号，メールアドレス，銀行口座番号，クレジットカード番号，運転免許証番号などの
-        個人情報をお尋ねすることがあります。また，ユーザーと提携先などとの間でなされたユーザーの個人情報を含む取引記録や決済に関する情報を,
+        個人情報をお尋ねすることがあります。また，ユーザーと提携先などとの間でなされたユーザーの個人情報を含む取引記録や決済に関する情報を，
         運営者の提携先（情報提供元，広告主，広告配信先などを含みます。以下，｢提携先｣といいます。）などから収集することがあります。
       </p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第3条（個人情報を収集・利用する目的）
-      </h2>
-      <p class="mb-2 font-medium">運営者が個人情報を収集・利用する目的は，以下のとおりです。</p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第3条（個人情報を収集・利用する目的）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">運営者が個人情報を収集・利用する目的は，以下のとおりです。</p>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>運営者サービスの提供・運営のため</li>
         <li>ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）</li>
         <li>ユーザーが利用中のサービスの新機能，更新情報，キャンペーン等及び運営者が提供する他のサービスの案内のメールを送付するため</li>
@@ -52,25 +44,21 @@
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第4条（利用目的の変更）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第4条（利用目的の変更）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>運営者は，利用目的が変更前と関連性を有すると合理的に認められる場合に限り，個人情報の利用目的を変更するものとします。</li>
         <li>利用目的の変更を行った場合には，変更後の目的について，運営者所定の方法により，ユーザーに通知し，または本ウェブサイト上に公表するものとします。</li>
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第5条（個人情報の第三者提供）
-      </h2>
-      <p class="mb-2 font-medium">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第5条（個人情報の第三者提供）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">
         運営者は，次に掲げる場合を除いて，あらかじめユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。
         ただし，個人情報保護法その他の法令で認められる場合を除きます。
       </p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>人の生命，身体または財産の保護のために必要がある場合であって，本人の同意を得ることが困難であるとき</li>
         <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって，本人の同意を得ることが困難であるとき</li>
         <li>
@@ -79,7 +67,7 @@
         </li>
         <li>
           <p class="mb-2">予め次の事項を告知あるいは公表し，かつ運営者が個人情報保護委員会に届出をしたとき</p>
-          <ol class="list-decimal list-outside pl-6">
+          <ol class="ml-6 list-outside list-decimal space-y-1">
             <li>利用目的に第三者への提供を含むこと</li>
             <li>第三者に提供されるデータの項目</li>
             <li>第三者への提供の手段または方法</li>
@@ -89,7 +77,7 @@
         </li>
         <li>
           <p class="mb-2">前項の定めにかかわらず，次に掲げる場合には，当該情報の提供先は第三者に該当しないものとします。</p>
-          <ol class="list-decimal list-outside pl-6">
+          <ol class="ml-6 list-outside list-decimal space-y-1">
             <li>運営者が利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合</li>
             <li>合併その他の事由による事業の承継に伴って個人情報が提供される場合</li>
             <li>
@@ -102,27 +90,23 @@
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第6条（個人情報の開示）
-      </h2>
-      <p class="mb-2 font-medium">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第6条（個人情報の開示）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">
         運営者は，本人から個人情報の開示を求められたときは，本人に対し，遅滞なくこれを開示します。ただし，開示することにより次のいずれかに該当する場合は，
         その全部または一部を開示しないこともあり，開示しない決定をした場合には，その旨を遅滞なく通知します。なお，個人情報の開示に際しては，1件あたり1，000円の手数料を申し受けます。
       </p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed mb-3">
         <li>本人または第三者の生命，身体，財産その他の権利利益を害するおそれがある場合</li>
         <li>運営者の業務の適正な実施に著しい支障を及ぼすおそれがある場合</li>
         <li>その他法令に違反することとなる場合</li>
       </ul>
-      <p class="mb-2">前項の定めにかかわらず，履歴情報および特性情報などの個人情報以外の情報については，原則として開示いたしません。</p>
+      <p class="text-sm text-gray-600 leading-relaxed">前項の定めにかかわらず，履歴情報および特性情報などの個人情報以外の情報については，原則として開示いたしません。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第7条（個人情報の訂正および削除）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第7条（個人情報の訂正および削除）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>
           ユーザーは，運営者の保有する自己の個人情報が誤った情報である場合には，運営者が定める手続きにより，
           運営者に対して個人情報の訂正，追加または削除（以下，「訂正等」といいます。）を請求することができます。
@@ -136,11 +120,9 @@
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第8条（個人情報の利用停止等）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第8条（個人情報の利用停止等）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>
           運営者は，本人から，個人情報が，利用目的の範囲を超えて取り扱われているという理由，または不正の手段により取得されたものであるという理由により，
           その利用の停止または消去（以下，「利用停止等」といいます。）を求められた場合には，遅滞なく必要な調査を行います。
@@ -158,11 +140,9 @@
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semiblid mb-4 border-l-4 border-blue-500 pl-3">
-        第9条（プライバシーポリシーの変更）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第9条（プライバシーポリシーの変更）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>
           本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。
         </li>
@@ -171,9 +151,5 @@
         </li>
       </ul>
     </section>
-  </div>
-
-  <div class="mt-16 text-center text-sm text-gray-400">
-    © 2026 サブスク管理 All Rights Reserved.
   </div>
 </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,181 +1,143 @@
 <% content_for :title, t("helpers.heading.terms") %>
 
-<div class="max-w-4xl mx-auto px-6 py-12">
-  <div class="mb-12 text-center">
-    <h1 class="text-4xl font-bold text-gray-900 mb-4"><%= t("helpers.term") %></h1>
-  </div>
+<div class="max-w-2xl mx-auto px-4 py-12">
+  <h1 class="text-3xl font-bold text-gray-900 mb-8"><%= t("helpers.term") %></h1>
 
-  <div class="bg-white shadow-md rounded-2xl p-8 mb-10">
-    <p class="mb-4">
-      この利用規約（以下，「本規約」といいます。）は，サブスク管理（以下，「運営者」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。
-    </p>
-    <p>
-      登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
-    </p>
-  </div>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-200 divide-y divide-gray-100">
+    <div class="p-8">
+      <p class="text-gray-600 leading-relaxed mb-3">
+        この利用規約（以下，「本規約」といいます。）は，サブスク管理（以下，「運営者」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。
+      </p>
+      <p class="text-gray-600 leading-relaxed">
+        登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
+      </p>
+    </div>
 
-  <div class="space-y-10">
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第1条（適用）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第1条（適用）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>本規約は，ユーザーと運営者との間の本サービスの利用に関わる一切の関係に適用されるものとします。</li>
         <li>運営者は本サービスに関し，本規約のほか，各種の定め（以下，「個別規定」といいます。）をすることがあります。</li>
         <li>本規約と個別規定が矛盾する場合には，個別規定が優先されるものとします。</li>
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第2条（利用登録）
-      </h2>
-      <p class="mb-4">登録希望者が本規約に同意し，運営者が承認することで利用登録が完了します。</p>
-      <p class="mb-2 font-medium">運営者は以下の場合、登録を承認しないことがあります：</p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第2条（利用登録）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed mb-3">登録希望者が本規約に同意し，運営者が承認することで利用登録が完了します。</p>
+      <p class="text-sm font-medium text-gray-700 mb-2">運営者は以下の場合、登録を承認しないことがあります：</p>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>虚偽の事項を届け出た場合</li>
         <li>本規約に違反したことがある者からの申請</li>
         <li>その他，運営者が相当でないと判断した場合</li>
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第3条（ユーザーIDおよびパスワードの管理）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第3条（ユーザーIDおよびパスワードの管理）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>ユーザーは自己の責任においてID・パスワードを管理するものとします。</li>
         <li>第三者への譲渡・貸与・共用は禁止します。</li>
         <li>第三者使用による損害について，運営者は故意・重大な過失を除き責任を負いません。</li>
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第4条（禁止事項）
-      </h2>
-      <div class="grid md:grid-cols-2 gap-4 text-gray-700">
-        <ul class="list-disc pl-6 space-y-2">
-          <li>法令または公序良俗に違反する行為</li>
-          <li>犯罪行為に関連する行為</li>
-          <li>本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為</li>
-          <li>サーバー・ネットワークを妨害する行為</li>
-          <li>本サービスによって得られた情報を商業的に利用する行為</li>
-          <li>運営者のサービスの運営を妨害するおそれのある行為</li>
-          <li>不正アクセスをし，またはこれを試みる行為</li>
-          <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
-        </ul>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>不正な目的を持って本サービスを利用する行為</li>
-          <li>本サービスの他のユーザーまたはその他の第三者に不利益，損害，不快感を与える行為</li>
-          <li>他のユーザーに成りすます行為</li>
-          <li>運営者が許諾しない本サービス上での宣伝，広告，勧誘，または営業行為</li>
-          <li>面識のない異性との出会いを目的とした行為</li>
-          <li>運営者のサービスに関連して，反社会的勢力に対して直接または間接に利益を供与する行為</li>
-          <li>その他，運営者が不適切と判断する行為</li>
-        </ul>
-      </div>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第4条（禁止事項）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為</li>
+        <li>サーバー・ネットワークを妨害する行為</li>
+        <li>本サービスによって得られた情報を商業的に利用する行為</li>
+        <li>運営者のサービスの運営を妨害するおそれのある行為</li>
+        <li>不正アクセスをし，またはこれを試みる行為</li>
+        <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+        <li>不正な目的を持って本サービスを利用する行為</li>
+        <li>本サービスの他のユーザーまたはその他の第三者に不利益，損害，不快感を与える行為</li>
+        <li>他のユーザーに成りすます行為</li>
+        <li>運営者が許諾しない本サービス上での宣伝，広告，勧誘，または営業行為</li>
+        <li>面識のない異性との出会いを目的とした行為</li>
+        <li>運営者のサービスに関連して，反社会的勢力に対して直接または間接に利益を供与する行為</li>
+        <li>その他，運営者が不適切と判断する行為</li>
+      </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第5条（本サービスの提供の停止等）
-      </h2>
-      <p class="mb-2 font-medium">運営者は，以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。：</p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第5条（本サービスの提供の停止等）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">運営者は，以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。</p>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed mb-3">
         <li>本サービスにかかるコンピュータシステムの保守点検または更新を行う場合</li>
         <li>地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合</li>
         <li>コンピュータまたは通信回線等が事故により停止した場合</li>
         <li>その他，運営者が本サービスの提供が困難と判断した場合</li>
       </ul>
-      <p class="mb-2">運営者は，本サービスの提供の停止または中断により，ユーザーまたは第三者が被ったいかなる不利益または損害についても，一切の責任を負わないものとします。</p>
+      <p class="text-sm text-gray-600 leading-relaxed">運営者は，本サービスの提供の停止または中断により，ユーザーまたは第三者が被ったいかなる不利益または損害についても，一切の責任を負わないものとします。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第6条（利用制限および登録抹消）
-      </h2>
-      <p class="mb-2 font-medium">運営者は，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。</p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第6条（利用制限および登録抹消）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">運営者は，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。</p>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed mb-3">
         <li>本規約のいずれかの条項に違反した場合</li>
         <li>登録事項に虚偽の事実があることが判明した場合</li>
         <li>運営者からの連絡に対し，一定期間返答がない場合</li>
         <li>本サービスについて，最終の利用から一定期間利用がない場合</li>
         <li>その他，運営者が本サービスの利用を適当でないと判断した場合</li>
       </ul>
-      <p class="mb-2">運営者は，本条に基づき運営者が行った行為によりユーザーに生じた損害について，一切の責任を負いません。</p>
+      <p class="text-sm text-gray-600 leading-relaxed">運営者は，本条に基づき運営者が行った行為によりユーザーに生じた損害について，一切の責任を負いません。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第7条（退会）
-      </h2>
-      <p class="mb-2">ユーザーは，運営者の定める退会手続により，本サービスから退会できるものとします。</p>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第7条（退会）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">ユーザーは，運営者の定める退会手続により，本サービスから退会できるものとします。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第8条（保証の否認および免責事項）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700">
-        <li>運営者は，本サービスに事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。</li>
-        <li>運営者は，本サービスに起因してユーザーに生じたあらゆる損害について、運営者の故意又は重過失による場合を除き、一切の責任を負いません。</li>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第8条（保証の否認および免責事項）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
+        <li>運営者は，本サービスに事実上または法律上の瑕疵がないことを明示的にも黙示的にも保証しておりません。</li>
+        <li>運営者は，本サービスに起因してユーザーに生じたあらゆる損害について，運営者の故意又は重過失による場合を除き，一切の責任を負いません。</li>
         <li>運営者は，本サービスに関して，ユーザーと他のユーザーまたは第三者との間において生じた取引，連絡または紛争等について一切責任を負いません。</li>
       </ul>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第9条（サービス内容の変更等）
-      </h2>
-      <p class="mb-2">運営者は，ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。</p>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第9条（サービス内容の変更等）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">運営者は，ユーザーへの事前の告知をもって，本サービスの内容を変更，追加または廃止することがあり，ユーザーはこれを承諾するものとします。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第10条（利用規約の変更）
-      </h2>
-      <p class="mb-2 font-medium">運営者は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。</p>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700 mb-4">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第10条（利用規約の変更）</h2>
+      <p class="text-sm font-medium text-gray-700 mb-2">運営者は以下の場合には，ユーザーの個別の同意を要せず，本規約を変更することができるものとします。</p>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed mb-3">
         <li>本規約の変更がユーザーの一般の利益に適合するとき。</li>
-        <li>本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。</li>
+        <li>本規約の変更が本サービス利用契約の目的に反せず，かつ，変更の必要性，変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。</li>
       </ul>
-      <p class="mb-2">運営者はユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</p>
+      <p class="text-sm text-gray-600 leading-relaxed">運営者はユーザーに対し，前項による本規約の変更にあたり，事前に，本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第11条（個人情報の取扱い）
-      </h2>
-      <p class="mb-2">運営者は，本サービスの利用によって取得する個人情報については，運営者「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第11条（個人情報の取扱い）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">運営者は，本サービスの利用によって取得する個人情報については，運営者「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第12条（通知または連絡）
-      </h2>
-      <p class="mb-2">ユーザーと運営者との間の通知または連絡は，運営者の定める方法によって行うものとします。運営者は,ユーザーから,運営者が別途定める方式に従った変更届け出がない限り,現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い,これらは,発信時にユーザーへ到達したものとみなします。</p>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第12条（通知または連絡）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">ユーザーと運営者との間の通知または連絡は，運営者の定める方法によって行うものとします。運営者は，ユーザーから，運営者が別途定める方式に従った変更届け出がない限り，現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い，これらは，発信時にユーザーへ到達したものとみなします。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第13条（権利義務の譲渡の禁止）
-      </h2>
-      <p class="mb-2">ユーザーは，運営者の書面による事前の承諾なく，利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し，または担保に供することはできません。</p>
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第13条（権利義務の譲渡の禁止）</h2>
+      <p class="text-sm text-gray-600 leading-relaxed">ユーザーは，運営者の書面による事前の承諾なく，利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し，または担保に供することはできません。</p>
     </section>
 
-    <section class="bg-white shadow-sm rounded-xl p-8 border border-gray-100">
-      <h2 class="text-xl font-semibold mb-4 border-l-4 border-blue-500 pl-3">
-        第14条（準拠法・裁判管轄）
-      </h2>
-      <ul class="list-disc pl-6 space-y-2 text-gray-700">
+    <section class="p-8">
+      <h2 class="text-base font-semibold text-gray-900 mb-4">第14条（準拠法・裁判管轄）</h2>
+      <ul class="ml-6 list-outside list-disc space-y-2 text-sm text-gray-600 leading-relaxed">
         <li>本規約の解釈にあたっては，日本法を準拠法とします。</li>
         <li>本サービスに関して紛争が生じた場合には，運営者の本店所在地を管轄する裁判所を専属的合意管轄とします。</li>
       </ul>
     </section>
-  </div>
-
-  <div class="mt-16 text-center text-sm text-gray-400">
-    © 2026 サブスク管理 All Rights Reserved.
   </div>
 </div>

--- a/app/views/payment_mailer/this_month_payment.html.erb
+++ b/app/views/payment_mailer/this_month_payment.html.erb
@@ -1,9 +1,27 @@
-<h2><%= t("helpers.heading.total_amount") %></h2>
-<p><%= number_to_currency(@this_month_payment, format: "%n%u") %></p>
+<p style="color: #111827; font-size: 15px; margin: 0 0 24px;">今月の支払いサービスをお知らせします。</p>
 
-<h2><%= t("helpers.heading.breakdown") %></h2>
-<% @this_month_payment_services.each do |service| %>
-  <p><%= service.name %></p>
-  <p><%= service.next_payment %></p>
-  <p><%= number_to_currency(service.price, format: "%n%u") %></p><br>
-<% end %>
+<div style="background: #eef2ff; border-radius: 12px; padding: 20px 24px; margin-bottom: 24px; text-align: center;">
+  <p style="color: #6366f1; font-size: 12px; font-weight: 600; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 0.05em;">今月の合計支払額</p>
+  <p style="color: #1e1b4b; font-size: 32px; font-weight: 700; margin: 0;">
+    <%= number_to_currency(@this_month_payment, format: "%n%u", unit: "円", delimiter: ",") %>
+  </p>
+</div>
+
+<table style="width: 100%; border-collapse: collapse;">
+  <thead>
+    <tr style="border-bottom: 2px solid #e5e7eb;">
+      <th style="text-align: left; padding: 8px 0; font-size: 12px; color: #6b7280; font-weight: 600;">サービス名</th>
+      <th style="text-align: right; padding: 8px 0; font-size: 12px; color: #6b7280; font-weight: 600;">支払日</th>
+      <th style="text-align: right; padding: 8px 0; font-size: 12px; color: #6b7280; font-weight: 600;">金額</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @this_month_payment_services.each do |service| %>
+    <tr style="border-bottom: 1px solid #f3f4f6;">
+      <td style="padding: 12px 0; font-size: 14px; color: #111827; font-weight: 500;"><%= service.name %></td>
+      <td style="padding: 12px 0; font-size: 13px; color: #6b7280; text-align: right;"><%= l(service.next_payment, format: :long) %></td>
+      <td style="padding: 12px 0; font-size: 14px; color: #111827; font-weight: 600; text-align: right;"><%= number_to_currency(service.price, format: "%n%u", unit: "円", delimiter: ",") %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,15 @@
-<% flash.each do |key, message| %>
-<% next if message.blank? %>
-  <div class="<%= flash_css_class(key) %> mx-auto max-w-md">
-    <%= message %>
+<div class="toast-container fixed top-4 right-4 z-50 flex flex-col gap-2">
+  <% flash.each do |key, message| %>
+  <% next if message.blank? %>
+  <div class="<%= flash_css_class(key) %>" data-controller="toast">
+    <div class="flex items-start gap-3">
+      <p class="toast__message flex-1 text-sm leading-snug"><%= message %></p>
+      <button class="toast__close opacity-50 hover:opacity-100 transition shrink-0 cursor-pointer" data-action="click->toast#dismiss">
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
   </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/subscription_services/_form.html.erb
+++ b/app/views/subscription_services/_form.html.erb
@@ -1,71 +1,67 @@
 <%= form_with(model: subscription_service, data: { controller: "preset" }) do |form| %>
-  <div data-controller="autocomplete" data-autocomplete-url-value="/subscription_services/search"
-       data-action="keydown.enter->preset#fill keydown.down->preset#select
-      keydown.up->preset#select"
-       role="combobox"
-       class="relative field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :name, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= form.text_field :name, data: { autocomplete_target: "input" },
-      class: "border-1 border-indigo-300 shadow-sm appearance-none
-      rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-    <ul id="presets" class="absolute list-group left-0 mt-1 w-full bg-white border
-               border-gray-200 rounded-md shadow-lg max-h-60 overflow-y-auto z-10 divide-y divide-gray-100"
-               data-autocomplete-target="results"></ul>
-  </div>
-  <% if subscription_service.errors.include?(:name) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= subscription_service.errors.full_messages_for(:name).first %>
-  </div>
-  <% end %>
-
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :next_payment, style: "display: block", class: "pb-1 text-gray-700" %>
-    <%= form.date_field :next_payment,
-      class: "border-1 border-indigo-300 shadow-sm appearance-none
-      rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
-  </div>
-  <% if subscription_service.errors.include?(:next_payment) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= subscription_service.errors.full_messages_for(:next_payment).first %>
-  </div>
-  <% end %>
-
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :payment_interval, style: "display: block", class: "pb-1 text-gray-700" %>
-    <div class="relative">
-      <%= form.number_field :payment_interval, min: 1,
-        class: "border-1 border-indigo-300 shadow-sm appearance-none
-        rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline pr-24" %>
-      <div class="absolute inset-y-0 right-0 flex items-center mr-2 ">
-        <%= form.select :payment_unit, [["ヶ月", "month"], ["年", "year"]] %>
-      </div>
+  <div class="subscription-form p-6 space-y-5">
+    <div class="form-field form-field--autocomplete relative"
+         data-controller="autocomplete" data-autocomplete-url-value="/subscription_services/search"
+         data-action="keydown.enter->preset#fill keydown.down->preset#select
+        keydown.up->preset#select"
+         role="combobox">
+      <%= form.label :name, class: "form-field__label block text-sm font-bold text-gray-700 mb-1" %>
+      <%= form.text_field :name, data: { autocomplete_target: "input" }, placeholder: "Netflix",
+        class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400
+        focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+      <ul id="presets" class="form-field__suggestions absolute left-0 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto z-10 divide-y divide-gray-100"
+                 data-autocomplete-target="results"></ul>
+      <p class="form-field__help mt-1 text-xs text-gray-500">サービス名を入力すると候補から自動入力できます。</p>
+      <% if subscription_service.errors.include?(:name) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= subscription_service.errors.full_messages_for(:name).first %></p>
+      <% end %>
     </div>
-  </div>
-  <% if subscription_service.errors.include?(:payment_interval) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= subscription_service.errors.full_messages_for(:payment_interval).first %>
-  </div>
-  <% end %>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.label :price, style: "display: block", class: "pb-1 text-gray-700" %>
-    <div class="relative">
-      <%= form.text_field :price,
-        class: "border-1 border-indigo-300 shadow-sm appearance-none
-        rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline pr-24" %>
-      <div class="absolute inset-y-0 right-0 flex items-center mr-2 ">
-        <%= form.select :monetary_unit, [["円", "JPY"], ["$", "USD"]] %>
+    <div class="form-field">
+      <%= form.label :next_payment, class: "form-field__label block text-sm font-bold text-gray-700 mb-1" %>
+      <div class="w-52 max-w-full">
+        <%= form.date_field :next_payment,
+          class: "form-field__input block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
       </div>
+      <% if subscription_service.errors.include?(:next_payment) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= subscription_service.errors.full_messages_for(:next_payment).first %></p>
+      <% end %>
     </div>
-  </div>
-  <% if subscription_service.errors.include?(:price) %>
-  <div class="mx-auto max-w-md text-red-800 pl-6">
-    <%= subscription_service.errors.full_messages_for(:price).first %>
-  </div>
-  <% end %>
 
-  <div class="field mx-auto max-w-md pt-6 pl-6 pr-6">
-    <%= form.submit class: "bg-white border border-gray-300
-      px-4 py-2 rounded hover:bg-gray-100 hover:cursor-pointer shadow-sm transition" %>
+    <div class="form-field">
+      <%= form.label :payment_interval, class: "form-field__label block text-sm font-bold text-gray-700 mb-1" %>
+      <div class="form-field__row flex gap-2">
+        <%= form.number_field :payment_interval, min: 1, placeholder: "1",
+          class: "form-field__input block w-24 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        <%= form.select :payment_unit, [["ヶ月", "month"], ["年", "year"]], {},
+          class: "form-field__select w-24 shrink-0 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 bg-white
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none" %>
+      </div>
+      <p class="form-field__help mt-1 text-xs text-gray-500">毎月なら「1ヶ月」、年額なら「1年」を指定します。</p>
+      <% if subscription_service.errors.include?(:payment_interval) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= subscription_service.errors.full_messages_for(:payment_interval).first %></p>
+      <% end %>
+    </div>
+
+    <div class="form-field">
+      <%= form.label :price, class: "form-field__label block text-sm font-bold text-gray-700 mb-1" %>
+      <div class="form-field__row flex gap-2">
+        <%= form.text_field :price, placeholder: "980",
+          class: "form-field__input block w-32 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none transition" %>
+        <%= form.select :monetary_unit, [["円", "JPY"], ["$", "USD"]], {},
+          class: "form-field__select w-24 shrink-0 rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 bg-white
+          focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 outline-none" %>
+      </div>
+      <% if subscription_service.errors.include?(:price) %>
+      <p class="form-field__error mt-1 text-sm text-red-600"><%= subscription_service.errors.full_messages_for(:price).first %></p>
+      <% end %>
+    </div>
+
+    <div class="form-actions pt-1">
+      <%= form.submit class: "form-actions__submit w-full bg-indigo-600 text-white text-sm font-semibold px-4 py-3 rounded-lg hover:bg-indigo-700 cursor-pointer transition" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/subscription_services/_subscription_service.html.erb
+++ b/app/views/subscription_services/_subscription_service.html.erb
@@ -1,19 +1,22 @@
-<div id="<%= dom_id subscription_service %>" class="p-6">
-  <h2 class="text-2xl font-bold mb-2">
-    <%= subscription_service.name %>
-  </h2>
-
-  <div class="ml-1">
-    <strong><%= t("activerecord.attributes.subscription_service.next_payment") %>:</strong>
-    <%= subscription_service.next_payment %>
+<div id="<%= dom_id subscription_service %>" class="subscription-card flex items-center gap-4 px-5 py-4">
+  <div class="subscription-card__info flex-1 min-w-0">
+    <h2 class="subscription-card__name font-semibold text-gray-900 truncate"><%= subscription_service.name %></h2>
+    <div class="subscription-card__meta flex items-center gap-3 mt-1 text-xs text-gray-400">
+      <span class="subscription-card__date inline-flex items-center gap-1">
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        次回 <%= subscription_service.next_payment %>
+      </span>
+      <span class="subscription-card__interval"><%= subscription_service.payment_interval %><%= payment_unit_to_ja(subscription_service.payment_unit) %>ごと</span>
+    </div>
   </div>
-
-  <div class="ml-1">
-    <strong><%= t("activerecord.attributes.subscription_service.payment_interval") %>:</strong>
-    <%= subscription_service.payment_interval %><%= payment_unit_to_ja(subscription_service.payment_unit) %>
+  <div class="subscription-card__price text-right shrink-0">
+    <p class="font-bold text-gray-900">
+      <%= subscription_service.price.to_formatted_s(:delimited) %><span class="text-xs font-normal text-gray-400 ml-0.5"><%= monetary_unit_to_ja(subscription_service.monetary_unit) %></span>
+    </p>
   </div>
-
-  <div class="mt-3 text-right text-2xl font-bold">
-    <%= subscription_service.price.to_formatted_s(:delimited) %><%= monetary_unit_to_ja(subscription_service.monetary_unit) %>
-  </div>
+  <svg xmlns="http://www.w3.org/2000/svg" class="subscription-card__chevron size-4 text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+  </svg>
 </div>

--- a/app/views/subscription_services/edit.html.erb
+++ b/app/views/subscription_services/edit.html.erb
@@ -1,14 +1,24 @@
 <% content_for :title, t("helpers.heading.edit", model: t("activerecord.models.subscription_service")) %>
 <% content_for :description, "サブスク管理のサービス編集画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.heading.edit", model: t("activerecord.models.subscription_service")) %>
-</h2>
+<div class="subscription-edit-page mx-auto max-w-md px-4 py-6">
+  <div class="page-header flex items-center gap-3 mb-6">
+    <%= link_to subscription_services_path, class: "page-header__back -m-2 p-2 text-gray-400 hover:text-gray-600 transition" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+    <% end %>
+    <h1 class="page-header__title text-2xl font-bold leading-tight text-gray-900"><%= t("helpers.heading.edit", model: t("activerecord.models.subscription_service")) %></h1>
+  </div>
 
-<%= render "form", subscription_service: @subscription_service %>
+  <div class="form-card bg-white rounded-2xl shadow-sm border border-gray-200 overflow-visible mb-4">
+    <%= render "form", subscription_service: @subscription_service %>
+  </div>
 
-<div class="field mx-auto max-w-md pt-6 pl-6 pr-6 mt-8">
-  <%= button_to t("helpers.submit.delete"), @subscription_service,
-      method: :delete, data: {turbo_confirm: "本当に削除しますか？"},
-      class: "bg-red-600 border border-red-300 text-white px-4 py-2 rounded hover:bg-red-800 hover:cursor-pointer shadow-sm transition" %>
+  <div class="danger-zone bg-white rounded-2xl shadow-sm border border-red-100 overflow-hidden p-5">
+    <p class="danger-zone__text text-sm text-gray-500 mb-3">このサービスを削除すると元に戻せません。</p>
+    <%= button_to t("helpers.submit.delete"), @subscription_service,
+        method: :delete, data: { turbo_confirm: "本当に削除しますか？" },
+        class: "danger-zone__delete bg-white border border-red-300 text-red-600 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-red-50 cursor-pointer transition" %>
+  </div>
 </div>

--- a/app/views/subscription_services/index.html.erb
+++ b/app/views/subscription_services/index.html.erb
@@ -1,35 +1,46 @@
 <% content_for :title, t("helpers.heading.list", model: t("activerecord.models.subscription_service")) %>
 <% content_for :description, "サブスク管理のサービス一覧画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.heading.list", model: t("activerecord.models.subscription_service")) %>
-</h2>
+<div class="subscription-list-page mx-auto max-w-2xl px-4 py-6">
+  <div class="subscription-list-page__header flex items-center justify-between mb-6">
+    <h1 class="subscription-list-page__title text-2xl font-bold leading-tight text-gray-900">マイサブスク</h1>
+    <%= link_to new_subscription_service_path,
+        class: "subscription-list-page__add-btn inline-flex items-center gap-1.5 bg-indigo-600 text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-indigo-700 transition" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+      </svg>
+      追加する
+    <% end %>
+  </div>
 
-<% if @subscription_services.present? %>
-<h3 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl font-bold">
-  <%= t("helpers.heading.total_amount") %>：<%= @this_month_payment.to_formatted_s(:delimited) %><%= t("number.currency.format.unit") %>
-</h3>
-<% end %>
+  <% if @subscription_services.present? %>
+  <div class="summary-card bg-indigo-600 text-white rounded-2xl p-6 mb-5 shadow-sm">
+    <p class="summary-card__label text-indigo-200 text-xs font-medium mb-1 uppercase tracking-wide"><%= t("helpers.heading.total_amount") %></p>
+    <p class="summary-card__amount text-4xl font-bold tracking-tight">
+      <%= @this_month_payment.to_formatted_s(:delimited) %><span class="text-xl font-medium ml-1"><%= t("number.currency.format.unit") %></span>
+    </p>
+    <p class="summary-card__count text-indigo-300 text-sm mt-1"><%= @subscription_services.count %>件のサービス</p>
+  </div>
 
-<div class="mx-auto max-w-md p-6">
-  <%= link_to t("activerecord.attributes.subscription_service.new"), new_subscription_service_path,
-      class: "bg-white border border-indigo-300 px-4 py-2 rounded hover:bg-gray-100
-	      hover:cursor-pointer shadow-sm transition" %>
-</div>
-
-<% if @subscription_services.present? %>
-<div id="subscription_services">
-  <% @subscription_services.each do |service| %>
-    <div class="mx-auto max-w-md bg-white border border-indigo-300 rounded-xl shadow-md overflow-hidden
-                transition transform hover:-translate-y-2 hover:shadow-xl duration-300 m-4">
-      <%= link_to edit_subscription_service_path(service) do %>
-        <%= render service %>
-      <% end %>
+  <div id="subscription_services" class="subscription-list space-y-2.5">
+    <% @subscription_services.each do |service| %>
+      <div class="subscription-list__item bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden hover:shadow-sm hover:border-indigo-300 transition duration-200">
+        <%= link_to edit_subscription_service_path(service), class: "block" do %>
+          <%= render service %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <% else %>
+  <div class="empty-state bg-white rounded-2xl p-12 text-center shadow-sm border border-gray-200">
+    <div class="empty-state__icon w-16 h-16 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-4">
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-8 text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+      </svg>
     </div>
+    <p class="empty-state__text text-gray-500 text-sm mb-5">まだサービスが登録されていません</p>
+    <%= link_to "最初のサブスクを追加する", new_subscription_service_path,
+        class: "empty-state__cta inline-flex items-center gap-1.5 bg-indigo-600 text-white text-sm font-semibold px-5 py-2.5 rounded-lg hover:bg-indigo-700 transition" %>
+  </div>
   <% end %>
 </div>
-<% else %>
-<p class="mx-auto max-w-md p-6 order-first text-md text-stone-900">
-  <%= t("helpers.subscription_service.no_service") %>
-</p>
-<% end %>

--- a/app/views/subscription_services/index.html.erb
+++ b/app/views/subscription_services/index.html.erb
@@ -13,6 +13,13 @@
     <% end %>
   </div>
 
+  <div class="subscription-list-page__help mb-6 rounded-2xl border border-indigo-100 bg-indigo-50/60 px-4 py-3">
+    <p class="text-sm font-semibold text-indigo-900">何を登録するページ？</p>
+    <p class="mt-1 text-sm leading-relaxed text-gray-600">
+      毎月または毎年支払っているサービスを登録できます。たとえば、動画配信、音楽配信、クラウドストレージ、AIツールなどの料金をまとめて管理できます。
+    </p>
+  </div>
+
   <% if @subscription_services.present? %>
   <div class="summary-card bg-indigo-600 text-white rounded-2xl p-6 mb-5 shadow-sm">
     <p class="summary-card__label text-indigo-200 text-xs font-medium mb-1 uppercase tracking-wide"><%= t("helpers.heading.total_amount") %></p>
@@ -38,7 +45,10 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
       </svg>
     </div>
-    <p class="empty-state__text text-gray-500 text-sm mb-5">まだサービスが登録されていません</p>
+    <p class="empty-state__text text-base font-semibold text-gray-700 mb-2">まだサービスが登録されていません</p>
+    <p class="empty-state__help mx-auto mb-6 max-w-md text-sm leading-relaxed text-gray-500">
+      Netflix、Spotify、iCloud+、ChatGPT Plus のように、定期的に料金が発生するサービスを登録してみてください。
+    </p>
     <%= link_to "最初のサブスクを追加する", new_subscription_service_path,
         class: "empty-state__cta inline-flex items-center gap-1.5 bg-indigo-600 text-white text-sm font-semibold px-5 py-2.5 rounded-lg hover:bg-indigo-700 transition" %>
   </div>

--- a/app/views/subscription_services/new.html.erb
+++ b/app/views/subscription_services/new.html.erb
@@ -1,8 +1,17 @@
 <% content_for :title, t("helpers.heading.new", model: t("activerecord.models.subscription_service")) %>
 <% content_for :description, "サブスク管理のサービス登録画面です。" %>
 
-<h2 class="mx-auto max-w-md p-6 order-first text-2xl text-stone-900 sm:text-2xl">
-  <%= t("helpers.heading.new", model: t("activerecord.models.subscription_service")) %>
-</h2>
+<div class="subscription-new-page mx-auto max-w-md px-4 py-6">
+  <div class="page-header flex items-center gap-3 mb-6">
+    <%= link_to subscription_services_path, class: "page-header__back -m-2 p-2 text-gray-400 hover:text-gray-600 transition" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+    <% end %>
+    <h1 class="page-header__title text-2xl font-bold leading-tight text-gray-900"><%= t("helpers.heading.new", model: t("activerecord.models.subscription_service")) %></h1>
+  </div>
 
-<%= render "form", subscription_service: @subscription_service %>
+  <div class="form-card bg-white rounded-2xl shadow-sm border border-gray-200 overflow-visible">
+    <%= render "form", subscription_service: @subscription_service %>
+  </div>
+</div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -78,7 +78,7 @@ ja:
       success: "%{kind} アカウントによる認証に成功しました。"
     passwords:
       edit:
-        change_my_password: パスワードを変更する
+        change_my_password: パスワード変更
         change_your_password: パスワードを変更
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
@@ -99,7 +99,7 @@ ja:
         cancel_my_account: 退会する
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
-        title: "%{resource}編集"
+        title: "登録情報変更"
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ if Rails.env.development?
     [
       { name: "Netflix", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 1590, monetary_unit: :JPY },
       { name: "Spotify Premium", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
-      { name: "iCloud+ 200GB", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 450, monetary_unit: :JPY },
+      { name: "iCloud+ 200GB", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 450, monetary_unit: :JPY }
     ].each do |attrs|
       user.subscription_services.create!(attrs)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,99 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# 開発用ユーザー（development環境のみ）
+if Rails.env.development?
+  admin = User.find_or_initialize_by(email: "admin@example.com")
+  if admin.new_record?
+    admin.password = "password"
+    admin.password_confirmation = "password"
+    admin.email_confirmation = "admin@example.com"
+    admin.role = :admin
+    admin.save!
+    puts "Created admin user: #{admin.email}"
+  end
+
+  user = User.find_or_initialize_by(email: "user@example.com")
+  if user.new_record?
+    user.password = "password"
+    user.password_confirmation = "password"
+    user.email_confirmation = "user@example.com"
+    user.save!
+    [
+      { name: "Netflix", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 1590, monetary_unit: :JPY },
+      { name: "Spotify Premium", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
+      { name: "iCloud+ 200GB", next_payment: Date.current.next_month, payment_interval: 1, payment_unit: :month, price: 450, monetary_unit: :JPY },
+    ].each do |attrs|
+      user.subscription_services.create!(attrs)
+    end
+    puts "Created general user: #{user.email} with #{user.subscription_services.count} services"
+  end
+end
+
+service_presets = [
+  { name: "Netflix", payment_interval: 1, payment_unit: :month, price: 1590, monetary_unit: :JPY },
+  { name: "Amazon Prime", payment_interval: 1, payment_unit: :month, price: 600, monetary_unit: :JPY },
+  { name: "Amazon Prime 年額", payment_interval: 1, payment_unit: :year, price: 5900, monetary_unit: :JPY },
+  { name: "Disney+", payment_interval: 1, payment_unit: :month, price: 1140, monetary_unit: :JPY },
+  { name: "Disney+ 年額", payment_interval: 1, payment_unit: :year, price: 11400, monetary_unit: :JPY },
+  { name: "Hulu", payment_interval: 1, payment_unit: :month, price: 1026, monetary_unit: :JPY },
+  { name: "U-NEXT", payment_interval: 1, payment_unit: :month, price: 2189, monetary_unit: :JPY },
+  { name: "ABEMAプレミアム", payment_interval: 1, payment_unit: :month, price: 1080, monetary_unit: :JPY },
+  { name: "dアニメストア", payment_interval: 1, payment_unit: :month, price: 550, monetary_unit: :JPY },
+  { name: "DAZN", payment_interval: 1, payment_unit: :month, price: 4200, monetary_unit: :JPY },
+  { name: "Leminoプレミアム", payment_interval: 1, payment_unit: :month, price: 990, monetary_unit: :JPY },
+  { name: "NHKオンデマンド", payment_interval: 1, payment_unit: :month, price: 990, monetary_unit: :JPY },
+  { name: "YouTube Premium", payment_interval: 1, payment_unit: :month, price: 1280, monetary_unit: :JPY },
+  { name: "YouTube Music Premium", payment_interval: 1, payment_unit: :month, price: 1080, monetary_unit: :JPY },
+  { name: "Spotify Premium", payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
+  { name: "Apple Music", payment_interval: 1, payment_unit: :month, price: 1080, monetary_unit: :JPY },
+  { name: "Amazon Music Unlimited", payment_interval: 1, payment_unit: :month, price: 1080, monetary_unit: :JPY },
+  { name: "LINE MUSIC", payment_interval: 1, payment_unit: :month, price: 1080, monetary_unit: :JPY },
+  { name: "AWA", payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
+  { name: "Audible", payment_interval: 1, payment_unit: :month, price: 1500, monetary_unit: :JPY },
+  { name: "Kindle Unlimited", payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
+  { name: "楽天マガジン", payment_interval: 1, payment_unit: :month, price: 572, monetary_unit: :JPY },
+  { name: "楽天マガジン 年額", payment_interval: 1, payment_unit: :year, price: 5500, monetary_unit: :JPY },
+  { name: "dマガジン", payment_interval: 1, payment_unit: :month, price: 580, monetary_unit: :JPY },
+  { name: "Nintendo Switch Online", payment_interval: 1, payment_unit: :year, price: 2400, monetary_unit: :JPY },
+  { name: "Nintendo Switch Online + 追加パック", payment_interval: 1, payment_unit: :year, price: 4900, monetary_unit: :JPY },
+  { name: "PlayStation Plus Essential", payment_interval: 1, payment_unit: :month, price: 850, monetary_unit: :JPY },
+  { name: "Xbox Game Pass Core", payment_interval: 1, payment_unit: :month, price: 842, monetary_unit: :JPY },
+  { name: "Xbox Game Pass Ultimate", payment_interval: 1, payment_unit: :month, price: 1450, monetary_unit: :JPY },
+  { name: "Adobe Creative Cloud コンプリートプラン", payment_interval: 1, payment_unit: :month, price: 7780, monetary_unit: :JPY },
+  { name: "Adobe Photoshop", payment_interval: 1, payment_unit: :month, price: 3280, monetary_unit: :JPY },
+  { name: "Canva Pro", payment_interval: 1, payment_unit: :month, price: 1500, monetary_unit: :JPY },
+  { name: "Canva Pro 年額", payment_interval: 1, payment_unit: :year, price: 11800, monetary_unit: :JPY },
+  { name: "Figma Professional", payment_interval: 1, payment_unit: :month, price: 15, monetary_unit: :USD },
+  { name: "Notion Plus", payment_interval: 1, payment_unit: :month, price: 10, monetary_unit: :USD },
+  { name: "Evernote Personal", payment_interval: 1, payment_unit: :month, price: 1100, monetary_unit: :JPY },
+  { name: "1Password", payment_interval: 1, payment_unit: :month, price: 3, monetary_unit: :USD },
+  { name: "Dropbox Plus", payment_interval: 1, payment_unit: :month, price: 1500, monetary_unit: :JPY },
+  { name: "Dropbox Professional", payment_interval: 1, payment_unit: :month, price: 2400, monetary_unit: :JPY },
+  { name: "Google One 100GB", payment_interval: 1, payment_unit: :month, price: 250, monetary_unit: :JPY },
+  { name: "Google One 2TB", payment_interval: 1, payment_unit: :month, price: 1300, monetary_unit: :JPY },
+  { name: "iCloud+ 50GB", payment_interval: 1, payment_unit: :month, price: 150, monetary_unit: :JPY },
+  { name: "iCloud+ 200GB", payment_interval: 1, payment_unit: :month, price: 450, monetary_unit: :JPY },
+  { name: "iCloud+ 2TB", payment_interval: 1, payment_unit: :month, price: 1500, monetary_unit: :JPY },
+  { name: "Microsoft 365 Personal", payment_interval: 1, payment_unit: :month, price: 1490, monetary_unit: :JPY },
+  { name: "Microsoft 365 Personal 年額", payment_interval: 1, payment_unit: :year, price: 14900, monetary_unit: :JPY },
+  { name: "GitHub Copilot", payment_interval: 1, payment_unit: :month, price: 10, monetary_unit: :USD },
+  { name: "ChatGPT Plus", payment_interval: 1, payment_unit: :month, price: 20, monetary_unit: :USD },
+  { name: "Claude Pro", payment_interval: 1, payment_unit: :month, price: 20, monetary_unit: :USD },
+  { name: "Perplexity Pro", payment_interval: 1, payment_unit: :month, price: 20, monetary_unit: :USD },
+  { name: "Midjourney Basic", payment_interval: 1, payment_unit: :month, price: 10, monetary_unit: :USD },
+  { name: "Midjourney Standard", payment_interval: 1, payment_unit: :month, price: 30, monetary_unit: :USD },
+  { name: "Cursor Pro", payment_interval: 1, payment_unit: :month, price: 20, monetary_unit: :USD },
+  { name: "X Premium", payment_interval: 1, payment_unit: :month, price: 980, monetary_unit: :JPY },
+  { name: "LinkedIn Premium", payment_interval: 1, payment_unit: :month, price: 2980, monetary_unit: :JPY },
+  { name: "食べログプレミアム", payment_interval: 1, payment_unit: :month, price: 330, monetary_unit: :JPY },
+  { name: "ピッコマWEB 待てば0円以外課金", payment_interval: 1, payment_unit: :month, price: 500, monetary_unit: :JPY }
+]
+
+service_presets.each do |attributes|
+  Admin::ServicePreset.find_or_create_by!(name: attributes[:name]) do |preset|
+    preset.payment_interval = attributes[:payment_interval]
+    preset.payment_unit = attributes[:payment_unit]
+    preset.price = attributes[:price]
+    preset.monetary_unit = attributes[:monetary_unit]
+  end
+end
+
+puts "Seeded #{Admin::ServicePreset.count} service presets"

--- a/test/system/service_presets_test.rb
+++ b/test/system/service_presets_test.rb
@@ -7,7 +7,6 @@ class ServicePresetsTest < ApplicationSystemTestCase
 
   test "make new service preset" do
     visit admin_root_url
-    assert_text "管理者画面"
     click_on "プリセットの作成"
 
     fill_in "サービス名", with: "Test Service"
@@ -21,7 +20,6 @@ class ServicePresetsTest < ApplicationSystemTestCase
 
   test "edit service preset" do
     visit admin_root_url
-    assert_text "管理者画面"
 
     click_on "ChatGPT(Plus)"
     assert_text "プリセットの編集"
@@ -33,7 +31,6 @@ class ServicePresetsTest < ApplicationSystemTestCase
 
   test "delete service preset" do
     visit admin_root_url
-    assert_text "管理者画面"
 
     click_on "Youtube Premium"
     assert_text "プリセットの編集"

--- a/test/system/subscription_services_test.rb
+++ b/test/system/subscription_services_test.rb
@@ -7,8 +7,8 @@ class SubscriptionServicesTest < ApplicationSystemTestCase
 
   test "make new subscription serivce" do
     visit subscription_services_url
-    assert_selector "h2", text: "サービス一覧"
-    click_on "サービスの登録"
+    assert_selector "h1", text: "マイサブスク"
+    click_on "追加する"
 
     fill_in "サービス名", with: "Youtube Premium"
     fill_in "次回支払日", with: Date.current
@@ -22,8 +22,8 @@ class SubscriptionServicesTest < ApplicationSystemTestCase
 
   test "no service name has been entered" do
     visit subscription_services_url
-    assert_selector "h2", text: "サービス一覧"
-    click_on "サービスの登録"
+    assert_selector "h1", text: "マイサブスク"
+    click_on "追加する"
 
     fill_in "次回支払日", with: Date.current
     fill_in "支払間隔", with: "1"
@@ -36,7 +36,7 @@ class SubscriptionServicesTest < ApplicationSystemTestCase
 
   test "edit subscription service" do
     visit subscription_services_url
-    assert_selector "h2", text: "サービス一覧"
+    assert_selector "h1", text: "マイサブスク"
     click_on "Youtube Premium"
 
     assert_text "サービスの編集"
@@ -50,7 +50,7 @@ class SubscriptionServicesTest < ApplicationSystemTestCase
 
   test "delete subscription service" do
     visit subscription_services_url
-    assert_selector "h2", text: "サービス一覧"
+    assert_selector "h1", text: "マイサブスク"
     click_on "Youtube Premium"
 
     assert_text "サービスの編集"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -4,7 +4,9 @@ class UsersTest < ApplicationSystemTestCase
   test "user registration" do
     visit root_url
     assert_text "サブスク管理"
-    click_on "初めての方はこちら"
+    within(".hero__actions") do
+      click_on "無料で始める"
+    end
 
     fill_in "Eメール", with: "test@sample.com"
     fill_in "Eメール（確認用）", with: "test@sample.com"
@@ -45,7 +47,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "現在のパスワード", with: "subsc_test"
     fill_in "パスワード", with: "fhfur@ER4g;l"
     fill_in "パスワード（確認用）", with: "fhfur@ER4g;l"
-    click_on "パスワードを変更する"
+    click_on "パスワード変更"
     assert_text "パスワードを更新しました"
   end
 


### PR DESCRIPTION
- 全フォームページのスタイルをTailwind v4で統一（auth-card、form-field等）
- Devise補助ページ（パスワードリセット・確認・ロック解除）をリデザイン
- トップページのモックUIを動的日付に変更
- メールテンプレートにインラインスタイルでデザインを追加
- 管理画面フォームを新スタイルに統一、英語テキストを日本語化
- トースト通知のStimulusコントローラーを追加
- admin_application.html.erbのHTML構造バグ（body外にheader/footer）を修正
- 利用規約・プライバシーポリシーを単一カードレイアウトに統一
- .env.exampleを追加、.gitignoreを整備
- README更新（技術スタック・環境変数・開発手順）
- seedsに開発用テストユーザーを追加